### PR TITLE
[ILX-52190] Android - On inspection questions, first question and 'Next' button are cut off when detail view is loaded

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -30,7 +30,7 @@ export default class Collapsible extends Component {
     if (!this.props.collapsed) {
       setTimeout(() => {
         this._measureContent((height) => this.state.height.setValue(height));
-      }, [1000])
+      }, 0)
     }
   }
 

--- a/Collapsible.js
+++ b/Collapsible.js
@@ -30,7 +30,7 @@ export default class Collapsible extends Component {
     if (!this.props.collapsed) {
       setTimeout(() => {
         this._measureContent((height) => this.state.height.setValue(height));
-      }, 0)
+      }, 0);
     }
   }
 

--- a/Collapsible.js
+++ b/Collapsible.js
@@ -28,7 +28,9 @@ export default class Collapsible extends Component {
 
   componentDidMount() {
     if (!this.props.collapsed) {
-      this._measureContent((height) => this.state.height.setValue(height));
+      setTimeout(() => {
+        this._measureContent((height) => this.state.height.setValue(height));
+      }, [1000])
     }
   }
 


### PR DESCRIPTION
*Summary - 
Develop/Android - On inspection questions, first question and ‘Next’ button are cut off when detail view is loaded

*Error states - 

* Site(s)Tested On - 
https://usevolapp01.intelex.com/mobile_automationlogin_sandbox/mobileApps_sandbox
Master 3.5, develop build , feature build - IntelexMobile-3.7.132-4.apk
iPhone 11 Pro Max, Pixel 4 XL, Emulator(Pixel9/OS15)

*Site(s) Defect Found On –
https://usevolapp01.intelex.com/mobile_automationlogin_sandbox/mobileApps_sandbox
develop build,feature build - IntelexMobile-3.7.132-4.apk
Pixel 4 XL,Emulator(Pixel9/OS15)

*Preconditions -
Do a clean install of the mobile app, as I think when I updated from master I couldn’t reproduce this.

*Steps to Reproduce (STR) - 

After installing the app, log in to the apps sandbox as mapps user
Go to Inspections tile > All Inspections tile
Search for badge and select record “UI Automation Dot Notication Badge”
                                                 OR

Go to Inspections tile > All Inspections tile

Search for “Calabash test-full-android“ and click on it and verify the Next button is getting cut off.

*Expected Result - 

Question 1 is fully displayed e.g.


*Actual Result - 
Question 1 is cut off




Workaround is that after interacting with question 1, or any element on the view, the question will fully display as expected